### PR TITLE
Visible satellites, partial pressure

### DIFF
--- a/src/main/java/com/hbm/dim/SkyProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/SkyProviderCelestial.java
@@ -12,6 +12,7 @@ import net.minecraft.util.Vec3;
 import net.minecraftforge.client.IRenderHandler;
 
 import java.util.List;
+import java.util.Map;
 
 import org.lwjgl.opengl.GL11;
 
@@ -19,6 +20,8 @@ import com.hbm.dim.SolarSystem.AstroMetric;
 import com.hbm.dim.trait.CBT_Atmosphere;
 import com.hbm.dim.trait.CelestialBodyTrait.CBT_SUNEXPLODED;
 import com.hbm.extprop.HbmLivingProps;
+import com.hbm.saveddata.SatelliteSavedData;
+import com.hbm.saveddata.satellites.Satellite;
 
 public class SkyProviderCelestial extends IRenderHandler {
 	
@@ -27,7 +30,6 @@ public class SkyProviderCelestial extends IRenderHandler {
 	private static final ResourceLocation overlayCrescent = new ResourceLocation("hbm:textures/misc/space/phase_overlay_crescent.png");
 	private static final ResourceLocation overlayHalf = new ResourceLocation("hbm:textures/misc/space/phase_overlay_half.png");
 	private static final ResourceLocation overlayGibbous = new ResourceLocation("hbm:textures/misc/space/phase_overlay_gibbous.png");
-	// private static final ResourceLocation flash = new ResourceLocation("hbm:textures/misc/space/flare.png");
 	private static final ResourceLocation flareTexture = new ResourceLocation("hbm:textures/misc/space/sunspike.png");
 	private static final ResourceLocation nightTexture = new ResourceLocation("hbm:textures/misc/space/night.png");
 	private static final ResourceLocation digammaStar = new ResourceLocation("hbm:textures/misc/space/star_digamma.png");
@@ -121,7 +123,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 		GL11.glDisable(GL11.GL_FOG);
 		GL11.glDisable(GL11.GL_ALPHA_TEST);
 		GL11.glEnable(GL11.GL_BLEND);
-		OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
 		RenderHelper.disableStandardItemLighting();
 
 		float starBrightness = world.getStarBrightness(partialTicks);
@@ -137,8 +139,8 @@ public class SkyProviderCelestial extends IRenderHandler {
 
 				mc.renderEngine.bindTexture(nightTexture);
 	
-				GL11.glEnable(3553);
-				GL11.glBlendFunc(770, 1);
+				GL11.glEnable(GL11.GL_TEXTURE_2D);
+				GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 	
 				float starBrightnessAlpha = starBrightness * 0.6f;
 				GL11.glColor4f(1.0F, 1.0F, 1.0F, starBrightnessAlpha);
@@ -171,7 +173,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 				
 				GL11.glRotatef(90.0F, 0.0F, 0.0F, 1.0F);
 				renderSkyboxSide(tessellator, 3);
-				GL11.glDisable(3553);
+				GL11.glDisable(GL11.GL_TEXTURE_2D);
 
 			}
 			GL11.glPopMatrix();
@@ -351,7 +353,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 			GL11.glPushMatrix();
 			{
 
-				OpenGlHelper.glBlendFunc(770, 1, 1, 0);
+				OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE, GL11.GL_ZERO);
 
 				float brightness = (float) Math.sin(celestialAngle * Math.PI);
 				brightness *= brightness;
@@ -376,6 +378,17 @@ public class SkyProviderCelestial extends IRenderHandler {
 
 			}
 			GL11.glPopMatrix();
+
+			// JEFF BOZOS WOULD LIKE TO KNOW YOUR LOCATION
+			// ... to send you a pakedge :)))
+			if(world.provider.dimensionId == 0) {
+				renderSatellite(partialTicks, world, mc, celestialAngle, 1916169, new float[] { 1.0F, 0.534F, 0.385F });
+			}
+
+			// Light up the sky
+			for(Map.Entry<Integer, Satellite> entry : SatelliteSavedData.getClientSats().entrySet()) {
+				renderSatellite(partialTicks, world, mc, celestialAngle, entry.getKey(), entry.getValue().getColor());
+			}
 
 			GL11.glDisable(GL11.GL_TEXTURE_2D);
 
@@ -452,6 +465,37 @@ public class SkyProviderCelestial extends IRenderHandler {
 	
 	public void renderSunset(float partialTicks, WorldClient world, Minecraft mc) {
 
+	}
+
+	private void renderSatellite(float partialTicks, WorldClient world, Minecraft mc, float celestialAngle, long seed, float[] color) {
+		Tessellator tessellator = Tessellator.instance;
+
+		float ticks = world.getWorldTime() + partialTicks;
+
+		GL11.glPushMatrix();
+		{
+
+			GL11.glRotatef(celestialAngle * -360.0F, 1.0F, 0.0F, 0.0F);
+			GL11.glRotatef(-40.0F + (float)(seed % 800) * 0.1F - 5.0F, 1.0F, 0.0F, 0.0F);
+			GL11.glRotatef((float)(seed % 50) * 0.1F - 20.0F, 0.0F, 1.0F, 0.0F);
+			GL11.glRotatef((float)(seed % 80) * 0.1F - 2.5F, 0.0F, 0.0F, 1.0F);
+			GL11.glRotatef((ticks / 600.0F) * 360.0F, 1.0F, 0.0F, 0.0F);
+			
+			GL11.glColor4f(color[0], color[1], color[2], 1F);
+			
+			mc.renderEngine.bindTexture(planetTexture);
+			
+			float size = 0.5F;
+			
+			tessellator.startDrawingQuads();
+			tessellator.addVertexWithUV(-size, 100.0, -size, 0.0D, 0.0D);
+			tessellator.addVertexWithUV(size, 100.0, -size, 0.0D, 1.0D);
+			tessellator.addVertexWithUV(size, 100.0, size, 1.0D, 1.0D);
+			tessellator.addVertexWithUV(-size, 100.0, size, 1.0D, 0.0D);
+			tessellator.draw();
+
+		}
+		GL11.glPopMatrix();
 	}
 	
 	// is just drawing a big cube with UVs prepared to draw a gradient

--- a/src/main/java/com/hbm/dim/SkyProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/SkyProviderCelestial.java
@@ -95,9 +95,12 @@ public class SkyProviderCelestial extends IRenderHandler {
 	@Override
 	public void render(float partialTicks, WorldClient world, Minecraft mc) {
 		CelestialBody body = CelestialBody.getBody(world);
+		CBT_Atmosphere atmosphere = body.getTrait(CBT_Atmosphere.class);
 
-		boolean hasAtmosphere = body.hasTrait(CBT_Atmosphere.class);
+		boolean hasAtmosphere = atmosphere != null;
 		boolean sundied = body.hasTrait(CBT_SUNEXPLODED.class);
+
+		float visibility = hasAtmosphere ? MathHelper.clamp_float(2.0F - atmosphere.getPressure(), 0.1F, 1.0F) : 1.0F;
 
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		Vec3 vec3 = world.getSkyColor(mc.renderViewEntity, partialTicks);
@@ -126,7 +129,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
 		RenderHelper.disableStandardItemLighting();
 
-		float starBrightness = world.getStarBrightness(partialTicks);
+		float starBrightness = world.getStarBrightness(partialTicks) * visibility;
 		float celestialAngle = world.getCelestialAngle(partialTicks);
 
 		// Handle any special per-body sunset rendering
@@ -205,13 +208,12 @@ public class SkyProviderCelestial extends IRenderHandler {
 				tessellator.addVertex(sunSize, 99.9D, sunSize);
 				tessellator.addVertex(-sunSize, 99.9D, sunSize);
 				tessellator.draw();
-
-				GL11.glEnable(GL11.GL_TEXTURE_2D);
-				GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 			}
 
 			// Draw the MIGHTY SUN
 			if(!sundied) {
+				GL11.glEnable(GL11.GL_TEXTURE_2D);
+				GL11.glColor4f(1.0F, 1.0F, 1.0F, visibility);
 
 				mc.renderEngine.bindTexture(SolarSystem.kerbol.texture);
 
@@ -221,12 +223,10 @@ public class SkyProviderCelestial extends IRenderHandler {
 				tessellator.addVertexWithUV(sunSize, 100.0D, sunSize, 1.0D, 1.0D);
 				tessellator.addVertexWithUV(-sunSize, 100.0D, sunSize, 0.0D, 1.0D);
 				tessellator.draw();
-
 			}
 
 			// Draw a big ol' spiky flare! Less so when there is an atmosphere
 			if(!sundied) {
-
 				if(hasAtmosphere) {
 					GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.25f);
 				}
@@ -239,7 +239,6 @@ public class SkyProviderCelestial extends IRenderHandler {
 				tessellator.addVertexWithUV(coronaSize, 100.0D, coronaSize, 1.0D, 1.0D);
 				tessellator.addVertexWithUV(-coronaSize, 100.0D, coronaSize, 0.0D, 1.0D);
 				tessellator.draw();
-
 			}
 
 			
@@ -270,13 +269,14 @@ public class SkyProviderCelestial extends IRenderHandler {
 					boolean renderAsPoint = size < minSize;
 
 					if(renderAsPoint) {
-						GL11.glColor4f(metric.body.color[0], metric.body.color[1], metric.body.color[2], (float)size * 100);
+						float alpha = MathHelper.clamp_float((float)size * 100.0F, 0.0F, 1.0F);
+						GL11.glColor4f(metric.body.color[0], metric.body.color[1], metric.body.color[2], alpha * visibility);
 						mc.renderEngine.bindTexture(planetTexture);
 
 						size = minSize;
 					} else {
 						GL11.glDisable(GL11.GL_BLEND);
-						GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+						GL11.glColor4f(1.0F, 1.0F, 1.0F, visibility);
 						mc.renderEngine.bindTexture(metric.body.texture);
 					}
 
@@ -303,7 +303,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 						double phase = Math.abs(metric.phase);
 						double sign = Math.signum(metric.phase);
 
-						GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+						GL11.glColor4f(1.0F, 1.0F, 1.0F, visibility);
 						GL11.glRotatef((float)sign * 90.0F - 90.0F, 0.0F, 1.0F, 0.0F);
 						
 						if(phase > 0.95F) {
@@ -329,7 +329,7 @@ public class SkyProviderCelestial extends IRenderHandler {
 						GL11.glDisable(GL11.GL_TEXTURE_2D);
 						
 						// Draw another layer on top to blend with the atmosphere
-						GL11.glColor4f(skyR - blendDarken, skyG - blendDarken, skyB - blendDarken, 1 - blendAmount);
+						GL11.glColor4f(skyR - blendDarken, skyG - blendDarken, skyB - blendDarken, (1 - blendAmount) * visibility);
 						OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE, GL11.GL_ZERO);
 	
 						tessellator.startDrawingQuads();
@@ -379,15 +379,17 @@ public class SkyProviderCelestial extends IRenderHandler {
 			}
 			GL11.glPopMatrix();
 
-			// JEFF BOZOS WOULD LIKE TO KNOW YOUR LOCATION
-			// ... to send you a pakedge :)))
-			if(world.provider.dimensionId == 0) {
-				renderSatellite(partialTicks, world, mc, celestialAngle, 1916169, new float[] { 1.0F, 0.534F, 0.385F });
-			}
-
-			// Light up the sky
-			for(Map.Entry<Integer, Satellite> entry : SatelliteSavedData.getClientSats().entrySet()) {
-				renderSatellite(partialTicks, world, mc, celestialAngle, entry.getKey(), entry.getValue().getColor());
+			if(visibility > 0.2F) {
+				// JEFF BOZOS WOULD LIKE TO KNOW YOUR LOCATION
+				// ... to send you a pakedge :)))
+				if(world.provider.dimensionId == 0) {
+					renderSatellite(partialTicks, world, mc, celestialAngle, 1916169, new float[] { 1.0F, 0.534F, 0.385F });
+				}
+	
+				// Light up the sky
+				for(Map.Entry<Integer, Satellite> entry : SatelliteSavedData.getClientSats().entrySet()) {
+					renderSatellite(partialTicks, world, mc, celestialAngle, entry.getKey(), entry.getValue().getColor());
+				}
 			}
 
 			GL11.glDisable(GL11.GL_TEXTURE_2D);

--- a/src/main/java/com/hbm/dim/SolarSystem.java
+++ b/src/main/java/com/hbm/dim/SolarSystem.java
@@ -49,7 +49,7 @@ public class SolarSystem {
 					.withRotationalPeriod(80_500)
 					.withColor(0.408F, 0.298F, 0.553F)
 					.withProcessingLevel(1)
-					.withTraits(new CBT_Atmosphere(1F, Fluids.EVEAIR, 100F), CelestialBodyTrait.HOT)
+					.withTraits(new CBT_Atmosphere(Fluids.EVEAIR, 5F), CelestialBodyTrait.HOT)
 					.withSatellites(
 						
 						new CelestialBody("gilly")
@@ -64,7 +64,7 @@ public class SolarSystem {
 					.withMassRadius(5.292e22F, 600)
 					.withSemiMajorAxis(13_599_840)
 					.withRotationalPeriod(21_549)
-					.withTraits(new CBT_Atmosphere(1F, Fluids.AIR, 100F), CelestialBodyTrait.BREATHABLE)
+					.withTraits(new CBT_Atmosphere(Fluids.AIR, 1F))
 					.withSatellites(
 
 						new CelestialBody("mun", SpaceConfig.moonDimension)
@@ -87,7 +87,7 @@ public class SolarSystem {
 					.withTidalLockingTo("ike")
 					.withColor(0.6471f, 0.2824f, 0.1608f)
 					.withProcessingLevel(1)
-					.withTraits(new CBT_Atmosphere(0.1F, Fluids.CARBONDIOXIDE, 100F))
+					.withTraits(new CBT_Atmosphere(Fluids.CARBONDIOXIDE, 0.1F))
 					.withSatellites(
 
 						new CelestialBody("ike", SpaceConfig.ikeDimension)
@@ -117,7 +117,7 @@ public class SolarSystem {
 							.withRotationalPeriod(52_981)
 							.withTidalLockingTo("jool")
 							.withProcessingLevel(3)
-							.withTraits(new CBT_Atmosphere(0.6F, Fluids.AIR, 100F), CelestialBodyTrait.BREATHABLE),
+							.withTraits(new CBT_Atmosphere(Fluids.AIR, 0.6F)),
 
 						new CelestialBody("vall")
 							.withMassRadius(3.109e21F, 300)

--- a/src/main/java/com/hbm/dim/SolarSystem.java
+++ b/src/main/java/com/hbm/dim/SolarSystem.java
@@ -49,7 +49,7 @@ public class SolarSystem {
 					.withRotationalPeriod(80_500)
 					.withColor(0.408F, 0.298F, 0.553F)
 					.withProcessingLevel(1)
-					.withTraits(new CBT_Atmosphere(1F,Fluids.EVEAIR, 10F), CelestialBodyTrait.HOT)
+					.withTraits(new CBT_Atmosphere(1F, Fluids.EVEAIR, 100F), CelestialBodyTrait.HOT)
 					.withSatellites(
 						
 						new CelestialBody("gilly")
@@ -64,7 +64,7 @@ public class SolarSystem {
 					.withMassRadius(5.292e22F, 600)
 					.withSemiMajorAxis(13_599_840)
 					.withRotationalPeriod(21_549)
-					.withTraits(new CBT_Atmosphere(1F, Fluids.AIR, 10F), CelestialBodyTrait.BREATHABLE)
+					.withTraits(new CBT_Atmosphere(1F, Fluids.AIR, 100F), CelestialBodyTrait.BREATHABLE)
 					.withSatellites(
 
 						new CelestialBody("mun", SpaceConfig.moonDimension)
@@ -87,7 +87,7 @@ public class SolarSystem {
 					.withTidalLockingTo("ike")
 					.withColor(0.6471f, 0.2824f, 0.1608f)
 					.withProcessingLevel(1)
-					.withTraits(new CBT_Atmosphere(0.1F, Fluids.CARBONDIOXIDE, 10F))
+					.withTraits(new CBT_Atmosphere(0.1F, Fluids.CARBONDIOXIDE, 100F))
 					.withSatellites(
 
 						new CelestialBody("ike", SpaceConfig.ikeDimension)
@@ -117,7 +117,7 @@ public class SolarSystem {
 							.withRotationalPeriod(52_981)
 							.withTidalLockingTo("jool")
 							.withProcessingLevel(3)
-							.withTraits(new CBT_Atmosphere(0.6F,Fluids.AIR, 1F), CelestialBodyTrait.BREATHABLE),
+							.withTraits(new CBT_Atmosphere(0.6F, Fluids.AIR, 100F), CelestialBodyTrait.BREATHABLE),
 
 						new CelestialBody("vall")
 							.withMassRadius(3.109e21F, 300)

--- a/src/main/java/com/hbm/dim/WorldProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/WorldProviderCelestial.java
@@ -46,6 +46,9 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 		float sun = this.getSunBrightnessFactor(1.0F);
 		float totalPressure = atmosphere.getPressure();
 		Vec3 color = Vec3.createVectorHelper(0, 0, 0);
+		
+		// Fog color difference factor
+		float factor = 1.0F;
 
 		for(CBT_Atmosphere.FluidEntry entry : atmosphere.fluids) {
 			Vec3 fluidColor;
@@ -62,6 +65,9 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 				fluidColor.xCoord *= sun;
 				fluidColor.yCoord *= sun;
 				fluidColor.zCoord *= sun;
+
+				// A bit hacky, but preserves existing planet colour behaviour
+				factor = 1.4F;
 			}
 
 			float percentage = entry.pressure / totalPressure;
@@ -71,8 +77,7 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 				color.zCoord + fluidColor.zCoord * percentage
 			);
 		}
-		
-		float factor = 1.4F;
+
 		color = Vec3.createVectorHelper(color.xCoord * factor, color.yCoord * factor, color.zCoord * factor);
 
 

--- a/src/main/java/com/hbm/dim/WorldProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/WorldProviderCelestial.java
@@ -46,9 +46,6 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 		float sun = this.getSunBrightnessFactor(1.0F);
 		float totalPressure = atmosphere.getPressure();
 		Vec3 color = Vec3.createVectorHelper(0, 0, 0);
-		
-		// Fog color difference factor
-		float factor = 1.0F;
 
 		for(CBT_Atmosphere.FluidEntry entry : atmosphere.fluids) {
 			Vec3 fluidColor;
@@ -62,12 +59,9 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 				fluidColor = super.getFogColor(x, y);
 			} else {
 				fluidColor = getColorFromHex(entry.fluid.getColor());
-				fluidColor.xCoord *= sun;
-				fluidColor.yCoord *= sun;
-				fluidColor.zCoord *= sun;
-
-				// A bit hacky, but preserves existing planet colour behaviour
-				factor = 1.4F;
+				fluidColor.xCoord *= sun * 1.4F;
+				fluidColor.yCoord *= sun * 1.4F;
+				fluidColor.zCoord *= sun * 1.4F;
 			}
 
 			float percentage = entry.pressure / totalPressure;
@@ -77,8 +71,6 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 				color.zCoord + fluidColor.zCoord * percentage
 			);
 		}
-
-		color = Vec3.createVectorHelper(color.xCoord * factor, color.yCoord * factor, color.zCoord * factor);
 
 
 		// Fog intensity remains high to simulate a thin looking atmosphere on low pressure planets

--- a/src/main/java/com/hbm/dim/trait/CBT_Atmosphere.java
+++ b/src/main/java/com/hbm/dim/trait/CBT_Atmosphere.java
@@ -14,86 +14,108 @@ import net.minecraftforge.common.util.Constants;
 
 public class CBT_Atmosphere extends CelestialBodyTrait {
 
-    public List<FluidEntry> fluids;
-    public float pressure;
+	public List<FluidEntry> fluids;
 
-    public static class FluidEntry {
-        public FluidType fluid;
-        public float percentage;
+	public static class FluidEntry {
+		public FluidType fluid;
+		public float pressure;
 
-        public FluidEntry(FluidType fluid, float percentage) {
-            this.fluid = fluid;
-            this.percentage = percentage;
-        }
-    }
+		public FluidEntry(FluidType fluid, float percentage) {
+			this.fluid = fluid;
+			this.pressure = percentage;
+		}
+	}
 
-    public CBT_Atmosphere() {
-        fluids = new ArrayList<>();
-    }
+	public CBT_Atmosphere() {
+		fluids = new ArrayList<>();
+	}
 
-    public CBT_Atmosphere(float pressure, Object... fluidData) {
-        this.pressure = pressure;
-        fluids = new ArrayList<>();
-        for (int i = 0; i < fluidData.length; i += 2) {
-            FluidType fluid = (FluidType) fluidData[i];
-            float percentage = (float) fluidData[i + 1];
-            fluids.add(new FluidEntry(fluid, percentage));
-        }
-    }
+	public CBT_Atmosphere(Object... fluidData) {
+		fluids = new ArrayList<>();
+		for (int i = 0; i < fluidData.length; i += 2) {
+			FluidType fluid = (FluidType) fluidData[i];
+			float percentage = (float) fluidData[i + 1];
+			fluids.add(new FluidEntry(fluid, percentage));
+		}
+	}
 
-    @Override
-    public void writeToNBT(NBTTagCompound nbt) {
-        nbt.setFloat("pressure", pressure);
-        NBTTagList fluidList = new NBTTagList();
-        for (FluidEntry entry : fluids) {
-            NBTTagCompound fluidTag = new NBTTagCompound();
-            fluidTag.setInteger("type", entry.fluid.getID());
-            fluidTag.setFloat("percentage", entry.percentage);
-            fluidList.appendTag(fluidTag);
-        }
-        nbt.setTag("fluids", fluidList);
-    }
+	public boolean hasFluid(FluidType fluid) {
+		for(FluidEntry entry : fluids) {
+			if(entry.fluid == fluid)
+				return true;
+		}
 
-    @Override
-    public void readFromNBT(NBTTagCompound nbt) {
-        pressure = nbt.getFloat("pressure");
-        fluids = new ArrayList<>();
-        NBTTagList fluidList = nbt.getTagList("fluids", Constants.NBT.TAG_COMPOUND);
-        for (int i = 0; i < fluidList.tagCount(); i++) {
-            NBTTagCompound fluidTag = fluidList.getCompoundTagAt(i);
-            FluidType fluid = Fluids.fromID(fluidTag.getInteger("type"));
-            float percentage = fluidTag.getFloat("percentage");
-            fluids.add(new FluidEntry(fluid, percentage));
-        }
-    }
+		return false;
+	}
 
-    @Override
-    public void writeToBytes(ByteBuf buf) {
-        buf.writeFloat(pressure);
-        buf.writeInt(fluids.size());
-        for (FluidEntry entry : fluids) {
-            buf.writeInt(entry.fluid.getID());
-            buf.writeFloat(entry.percentage);
-        }
-    }
+	public boolean hasFluid(FluidType fluid, float abovePressure) {
+		for(FluidEntry entry : fluids) {
+			if(entry.fluid == fluid && entry.pressure >= abovePressure)
+				return true;
+		}
 
-    @Override
-    public void readFromBytes(ByteBuf buf) {
-        pressure = buf.readFloat();
-        int size = buf.readInt();
-        fluids = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            FluidType fluid = Fluids.fromID(buf.readInt());
-            float percentage = buf.readFloat();
-            fluids.add(new FluidEntry(fluid, percentage));
-        }
-    }
+		return false;
+	}
 
-    public List<Integer> getFluidColors() {
-        List<Integer> colors = new ArrayList<>();
-        for (FluidEntry entry : fluids) {
-            colors.add(entry.fluid.getColor());
-        }
-        return colors;
-    }
+	// FluidEntries store PARTIAL pressure, to get the total atmospheric pressure, use this method
+	public float getPressure() {
+		float pressure = 0;
+		for(FluidEntry entry: fluids) {
+			pressure += entry.pressure;
+		}
+
+		return pressure;
+	}
+
+	public List<Integer> getFluidColors() {
+		List<Integer> colors = new ArrayList<>();
+		for (FluidEntry entry : fluids) {
+			colors.add(entry.fluid.getColor());
+		}
+		return colors;
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		NBTTagList fluidList = new NBTTagList();
+		for (FluidEntry entry : fluids) {
+			NBTTagCompound fluidTag = new NBTTagCompound();
+			fluidTag.setInteger("type", entry.fluid.getID());
+			fluidTag.setFloat("percentage", entry.pressure);
+			fluidList.appendTag(fluidTag);
+		}
+		nbt.setTag("fluids", fluidList);
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		fluids = new ArrayList<>();
+		NBTTagList fluidList = nbt.getTagList("fluids", Constants.NBT.TAG_COMPOUND);
+		for (int i = 0; i < fluidList.tagCount(); i++) {
+			NBTTagCompound fluidTag = fluidList.getCompoundTagAt(i);
+			FluidType fluid = Fluids.fromID(fluidTag.getInteger("type"));
+			float percentage = fluidTag.getFloat("percentage");
+			fluids.add(new FluidEntry(fluid, percentage));
+		}
+	}
+
+	@Override
+	public void writeToBytes(ByteBuf buf) {
+		buf.writeInt(fluids.size());
+		for (FluidEntry entry : fluids) {
+			buf.writeInt(entry.fluid.getID());
+			buf.writeFloat(entry.pressure);
+		}
+	}
+
+	@Override
+	public void readFromBytes(ByteBuf buf) {
+		int size = buf.readInt();
+		fluids = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			FluidType fluid = Fluids.fromID(buf.readInt());
+			float percentage = buf.readFloat();
+			fluids.add(new FluidEntry(fluid, percentage));
+		}
+	}
 }

--- a/src/main/java/com/hbm/dim/trait/CelestialBodyTrait.java
+++ b/src/main/java/com/hbm/dim/trait/CelestialBodyTrait.java
@@ -12,10 +12,6 @@ public abstract class CelestialBodyTrait {
 
 	// Similarly to fluid traits, we have classes, and instance members.
 	// For the simple traits, we'll just init both here rather than two places.
-	
-	// Breathable MAY be just replaced with a check against PT_Atmosphere
-	public static class CBT_Breathable extends CelestialBodyTrait { }
-	public static CBT_Breathable BREATHABLE = new CBT_Breathable();
 
 	public static class CBT_Hot extends CelestialBodyTrait { }
 	public static CBT_Hot HOT = new CBT_Hot();
@@ -28,20 +24,18 @@ public abstract class CelestialBodyTrait {
 	
 	public static class CBT_SUNEXPLODED extends CelestialBodyTrait { }
 	public static CBT_SUNEXPLODED SPLODE = new CBT_SUNEXPLODED();
+
 	// Constructor and loading
 	public static List<Class<? extends CelestialBodyTrait>> traitList = new ArrayList<Class<? extends CelestialBodyTrait>>();
 	public static HashBiMap<String, Class<? extends CelestialBodyTrait>> traitMap = HashBiMap.create();
 
 	static {
 		registerTrait("atmosphere", CBT_Atmosphere.class);
-		registerTrait("breathable", CBT_Breathable.class);
 		registerTrait("hot", CBT_Hot.class);
 		registerTrait("cold", CBT_Cold.class);
 		registerTrait("hotter", CBT_Temperature.class);
 		registerTrait("war", CBT_War.class);
 		registerTrait("sunexploded", CBT_SUNEXPLODED.class);
-
-
 	};
 
 	private static void registerTrait(String name, Class<? extends CelestialBodyTrait> clazz) {

--- a/src/main/java/com/hbm/handler/EntityEffectHandler.java
+++ b/src/main/java/com/hbm/handler/EntityEffectHandler.java
@@ -185,7 +185,7 @@ public class EntityEffectHandler {
 			return;
 		
 		List<ContaminationEffect> contamination = HbmLivingProps.getCont(entity);
-		List<ContaminationEffect> rem = new ArrayList();
+		List<ContaminationEffect> rem = new ArrayList<ContaminationEffect>();
 		
 		for(ContaminationEffect con : contamination) {
 			ContaminationUtil.contaminate(entity, HazardType.RADIATION, con.ignoreArmor ? ContaminationType.RAD_BYPASS : ContaminationType.CREATIVE, con.getRad());
@@ -297,26 +297,26 @@ public class EntityEffectHandler {
 	}
 
 	private static void handleOxy(EntityLivingBase entity) {
-	    CBT_Atmosphere atmosphere = CelestialBody.getTrait(entity.worldObj, CBT_Atmosphere.class);
+		CBT_Atmosphere atmosphere = CelestialBody.getTrait(entity.worldObj, CBT_Atmosphere.class);
 
-	    if (atmosphere == null) {
-            HbmLivingProps.setOxy(entity, HbmLivingProps.getOxy(entity) - 1);
-            return;
-	    }
-	        boolean hasBreathableAir = false;
+		if (atmosphere == null) {
+			HbmLivingProps.setOxy(entity, HbmLivingProps.getOxy(entity) - 1);
+			return;
+		}
 
-	        for (CBT_Atmosphere.FluidEntry entry : atmosphere.fluids) {
-	            if (entry.fluid == Fluids.AIR && entry.percentage >= 21.0F) { // Assuming 21% AIR is required for breathable atmosphere
-	                hasBreathableAir = true;
-	                break;
-	            }
-	        }
+		boolean hasBreathableAir = false;
 
-	        if (!ArmorUtil.checkForOxy(entity) && !hasBreathableAir && !(entity instanceof EntityGlyphid)) {
-	            HbmLivingProps.setOxy(entity, HbmLivingProps.getOxy(entity) - 1);
-	            return;
-	        
-	    }
+		for (CBT_Atmosphere.FluidEntry entry : atmosphere.fluids) {
+			if (entry.fluid == Fluids.AIR && entry.percentage >= 21.0F) { // Assuming 21% AIR is required for breathable atmosphere
+				hasBreathableAir = true;
+				break;
+			}
+		}
+
+		if (!ArmorUtil.checkForOxy(entity) && !hasBreathableAir && !(entity instanceof EntityGlyphid)) {
+			HbmLivingProps.setOxy(entity, HbmLivingProps.getOxy(entity) - 1);
+			return;
+		}
 	}
 
 	private static void handleDigamma(EntityLivingBase entity) {

--- a/src/main/java/com/hbm/handler/EntityEffectHandler.java
+++ b/src/main/java/com/hbm/handler/EntityEffectHandler.java
@@ -304,14 +304,7 @@ public class EntityEffectHandler {
 			return;
 		}
 
-		boolean hasBreathableAir = false;
-
-		for (CBT_Atmosphere.FluidEntry entry : atmosphere.fluids) {
-			if (entry.fluid == Fluids.AIR && entry.percentage >= 21.0F) { // Assuming 21% AIR is required for breathable atmosphere
-				hasBreathableAir = true;
-				break;
-			}
-		}
+		boolean hasBreathableAir = atmosphere.hasFluid(Fluids.AIR, 0.21F) || atmosphere.hasFluid(Fluids.OXYGEN, 0.09F); // Assuming 21% AIR/9% OXY is required for breathable atmosphere
 
 		if (!ArmorUtil.checkForOxy(entity) && !hasBreathableAir && !(entity instanceof EntityGlyphid)) {
 			HbmLivingProps.setOxy(entity, HbmLivingProps.getOxy(entity) - 1);

--- a/src/main/java/com/hbm/items/tool/ItemWandD.java
+++ b/src/main/java/com/hbm/items/tool/ItemWandD.java
@@ -144,7 +144,7 @@ public class ItemWandD extends Item {
 					CelestialBody.clearTraits(world);
 					player.addChatMessage(new ChatComponentText("RETURN TO MEAN"));
 				} else {
-					CelestialBody.setTraits(world, new CBT_Atmosphere(1F, Fluids.COALCREOSOTE, 10F), new CBT_Temperature(10F));
+					CelestialBody.setTraits(world, new CBT_Atmosphere(Fluids.COALCREOSOTE, 1F), new CBT_Temperature(10F));
 					player.addChatMessage(new ChatComponentText("Made MOHO HORRIBLE, why did you do this."));
 				}
 			}
@@ -154,7 +154,7 @@ public class ItemWandD extends Item {
 					CelestialBody.clearTraits(world);
 					player.addChatMessage(new ChatComponentText("ONE MILLION DEAD WORLDS"));
 				} else {
-					CelestialBody.setTraits(world, new CBT_Atmosphere(1F, Fluids.AIR, 25F), new CBT_Temperature(10F));
+					CelestialBody.setTraits(world, new CBT_Atmosphere(Fluids.AIR, 1F), new CBT_Temperature(10F));
 					player.addChatMessage(new ChatComponentText("Made MOON breathable."));
 				}
 			}

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -17,6 +17,7 @@ import com.hbm.blocks.ModBlocks;
 import com.hbm.blocks.generic.BlockAshes;
 import com.hbm.config.GeneralConfig;
 import com.hbm.config.SpaceConfig;
+import com.hbm.dim.SkyProviderCelestial;
 import com.hbm.dim.duna.WorldProviderDuna;
 import com.hbm.dim.eve.WorldProviderEve;
 import com.hbm.entity.mob.EntityHunterChopper;
@@ -64,7 +65,6 @@ import com.hbm.render.util.RenderAccessoryUtility;
 import com.hbm.render.util.RenderOverhead;
 import com.hbm.render.util.RenderScreenOverlay;
 import com.hbm.render.util.SoyuzPronter;
-import com.hbm.render.world.RenderNTMSkyboxChainloader;
 import com.hbm.render.world.RenderNTMSkyboxImpact;
 import com.hbm.sound.MovingSoundChopper;
 import com.hbm.sound.MovingSoundChopperMine;
@@ -136,6 +136,7 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
+import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProviderSurface;
 import net.minecraftforge.client.GuiIngameForge;
@@ -223,7 +224,7 @@ public class ModEventHandlerClient {
 			
 			if(mop != null) {
 				
-				if(mop.typeOfHit == mop.typeOfHit.BLOCK) {
+				if(mop.typeOfHit == MovingObjectType.BLOCK) {
 					
 					if(player.getHeldItem() != null && player.getHeldItem().getItem() instanceof ILookOverlay) {
 						((ILookOverlay) player.getHeldItem().getItem()).printHook(event, world, mop.blockX, mop.blockY, mop.blockZ);
@@ -236,7 +237,7 @@ public class ModEventHandlerClient {
 					text.add("Meta: " + world.getBlockMetadata(mop.blockX, mop.blockY, mop.blockZ));
 					ILookOverlay.printGeneric(event, "DEBUG", 0xffff00, 0x4040000, text);*/
 					
-				} else if(mop.typeOfHit == mop.typeOfHit.ENTITY) {
+				} else if(mop.typeOfHit == MovingObjectType.ENTITY) {
 					Entity entity = mop.entityHit;
 					
 					if(entity instanceof ILookOverlay) {
@@ -360,7 +361,7 @@ public class ModEventHandlerClient {
 		/// HANDLE SCOPE OVERLAY ///
 		ItemStack held = player.getHeldItem();
 		
-		if(player.isSneaking() && held != null && held.getItem() instanceof ItemGunBase && event.type == event.type.HOTBAR)  {
+		if(player.isSneaking() && held != null && held.getItem() instanceof ItemGunBase && event.type == ElementType.HOTBAR)  {
 			GunConfiguration config = ((ItemGunBase) held.getItem()).mainConfig;
 			
 			if(config.scopeTexture != null) {
@@ -379,7 +380,7 @@ public class ModEventHandlerClient {
 		if(helmet != null && helmet.getItem() instanceof ArmorFSB) {
 			((ArmorFSB)helmet.getItem()).handleOverlay(event, player);
 		}
-		if(!event.isCanceled() && event.type == event.type.HOTBAR) {
+		if(!event.isCanceled() && event.type == ElementType.HOTBAR) {
 			
 			HbmPlayerProps props = HbmPlayerProps.getData(player);
 			if(props.getDashCount() > 0) {
@@ -395,7 +396,7 @@ public class ModEventHandlerClient {
 
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 		
-		if(event.type == event.type.ARMOR) {
+		if(event.type == ElementType.ARMOR) {
 
 			HbmPlayerProps props = HbmPlayerProps.getData(player);
 			if(props.getEffectiveMaxShield() > 0) {
@@ -412,7 +413,7 @@ public class ModEventHandlerClient {
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 		Tessellator tess = Tessellator.instance;
 		
-		if(!event.isCanceled() && event.type == event.type.HEALTH) {
+		if(!event.isCanceled() && event.type == ElementType.HEALTH) {
 			HbmPlayerProps props = HbmPlayerProps.getData(player);
 			if(props.maxShield > 0) {
 				RenderScreenOverlay.renderShieldBar(event.resolution, Minecraft.getMinecraft().ingameGUI);
@@ -421,15 +422,16 @@ public class ModEventHandlerClient {
 				RenderScreenOverlay.renderTaintBar(event.resolution, Minecraft.getMinecraft().ingameGUI);
 			}
 		}
-		if (!event.isCanceled() && event.type == event.type.ALL)
-		{
+
+		if (!event.isCanceled() && event.type == ElementType.ALL) {
 			long time = ImpactWorldHandler.getTimeForClient(player.worldObj);
 			if(time>0)
 			{
 				RenderScreenOverlay.renderCountdown(event.resolution, Minecraft.getMinecraft().ingameGUI, Minecraft.getMinecraft().theWorld);	
 			}        	
 		}
-		if(event.type == event.type.ARMOR) {
+
+		if(event.type == ElementType.ARMOR) {
 			
 			if(ForgeHooks.getTotalArmorValue(player) == 0) {
 				GuiIngameForge.left_height -= 10;
@@ -465,6 +467,7 @@ public class ModEventHandlerClient {
 				GL11.glEnable(GL11.GL_TEXTURE_2D);
 
 			}
+
 			if(ArmorFSB.hasFSBArmorIgnoreCharge(player)) {
 				ArmorFSB chestplate = (ArmorFSB) player.inventory.armorInventory[2].getItem();
 				boolean noHelmet = chestplate.noHelmet;
@@ -506,7 +509,7 @@ public class ModEventHandlerClient {
 
 				ItemStack stack = player.inventory.armorInventory[2];
 
-				float tot = (float) ((JetpackBase) stack.getItem()).getFuel(stack) / (float) ((JetpackBase) stack.getItem()).getMaxFill(stack);
+				float tot = (float) JetpackBase.getFuel(stack) / (float) ((JetpackBase) stack.getItem()).getMaxFill(stack);
 				
 				int top = height - GuiIngameForge.left_height + 3;
 
@@ -864,8 +867,7 @@ public class ModEventHandlerClient {
 		///NEUTRON ACTIVATION
 		float level = 0;
 		float rads = HazardSystem.getHazardLevelFromStack(stack, HazardRegistry.RADIATION);
-		if(HazardSystem.getHazardLevelFromStack(stack, HazardRegistry.RADIATION)==0)
-		{
+		if(rads == 0) {
 			if(stack.hasTagCompound() && stack.stackTagCompound.hasKey("ntmNeutron")) {
 				level += stack.stackTagCompound.getFloat("ntmNeutron");
 			}
@@ -1033,12 +1035,12 @@ public class ModEventHandlerClient {
 			if(BlockAshes.ashes < 0) BlockAshes.ashes = 0;
 			
 			if(mc.theWorld.getTotalWorldTime() % 20 == 0) {
-				this.lastBrightness = this.currentBrightness;
+				lastBrightness = currentBrightness;
 				currentBrightness = mc.theWorld.getLightBrightnessForSkyBlocks(MathHelper.floor_double(mc.thePlayer.posX), MathHelper.floor_double(mc.thePlayer.posY), MathHelper.floor_double(mc.thePlayer.posZ), 0);
 			}
 			
 			if(ArmorUtil.isWearingEmptyMask(mc.thePlayer)) {
-				MainRegistry.proxy.displayTooltip(EnumChatFormatting.RED + "Your mask has no filter!", MainRegistry.proxy.ID_FILTER);
+				MainRegistry.proxy.displayTooltip(EnumChatFormatting.RED + "Your mask has no filter!", ServerProxy.ID_FILTER);
 			}
 		}
 		
@@ -1118,7 +1120,7 @@ public class ModEventHandlerClient {
 			
 			if(player.inventory.armorInventory[2] != null && player.inventory.armorInventory[2].getItem() instanceof ArmorFSB) {
 				ArmorFSB plate = (ArmorFSB) player.inventory.armorInventory[2].getItem();
-				if(plate.hasFSBArmor(player)) newStepSize = plate.stepSize;
+				if(ArmorFSB.hasFSBArmor(player)) newStepSize = plate.stepSize;
 			}
 			
 			if(newStepSize > 0) {
@@ -1172,14 +1174,18 @@ public class ModEventHandlerClient {
 			
 			IRenderHandler sky = world.provider.getSkyRenderer();
 			
-			if(world.provider instanceof WorldProviderSurface) {
-				world.provider.setSkyRenderer(new RenderNTMSkyboxImpact());
-				return;
-			}
+			// if(world.provider instanceof WorldProviderSurface) {
+			// 	if(!(sky instanceof RenderNTMSkyboxImpact)) {
+			// 		world.provider.setSkyRenderer(new RenderNTMSkyboxImpact());
+			// 		return;
+			// 	}
+			// }
 
+			// Since we aren't just adding a star or two, we can't employ the chainloader,
+			// sorry, no custom skyboxes for SHPAYCE!
 			if(world.provider.dimensionId == 0) {
-				if(!(sky instanceof RenderNTMSkyboxChainloader)) {
-					world.provider.setSkyRenderer(new RenderNTMSkyboxChainloader(sky));
+				if(!(sky instanceof SkyProviderCelestial)) {
+					world.provider.setSkyRenderer(new SkyProviderCelestial());
 				}
 			}
 		}

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -17,9 +17,11 @@ import com.hbm.blocks.ModBlocks;
 import com.hbm.blocks.generic.BlockAshes;
 import com.hbm.config.GeneralConfig;
 import com.hbm.config.SpaceConfig;
+import com.hbm.dim.CelestialBody;
 import com.hbm.dim.SkyProviderCelestial;
 import com.hbm.dim.duna.WorldProviderDuna;
 import com.hbm.dim.eve.WorldProviderEve;
+import com.hbm.dim.trait.CBT_Atmosphere;
 import com.hbm.entity.mob.EntityHunterChopper;
 import com.hbm.entity.projectile.EntityChopperMine;
 import com.hbm.entity.train.EntityRailCarRidable;
@@ -1382,17 +1384,16 @@ public class ModEventHandlerClient {
 
 	@SubscribeEvent
 	public void thickenFog(FogDensity event) {
-		if (event.entity.worldObj.provider instanceof WorldProviderEve) {
-				if(GLContext.getCapabilities().GL_NV_fog_distance) {
-					GL11.glFogi(34138, 34139);
-				}
-				GL11.glFogi(GL11.GL_FOG_MODE, GL11.GL_EXP);
+		CBT_Atmosphere atmosphere = CelestialBody.getTrait(event.entity.worldObj, CBT_Atmosphere.class);
+		if (atmosphere != null && atmosphere.getPressure() > 2F) {
+			if(GLContext.getCapabilities().GL_NV_fog_distance) {
+				GL11.glFogi(34138, 34139);
+			}
+			GL11.glFogi(GL11.GL_FOG_MODE, GL11.GL_EXP);
 
-				event.density = 0.045F;
-				event.setCanceled(true);
-			
+			event.density = 0.045F;
+			event.setCanceled(true);
 		}
-
 	}
 	
 	@SubscribeEvent

--- a/src/main/java/com/hbm/saveddata/SatelliteSavedData.java
+++ b/src/main/java/com/hbm/saveddata/SatelliteSavedData.java
@@ -1,6 +1,9 @@
 package com.hbm.saveddata;
 
 import com.hbm.saveddata.satellites.Satellite;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
@@ -77,4 +80,17 @@ public class SatelliteSavedData extends WorldSavedData {
 	    
 	    return data;
 	}
+
+	public static HashMap<Integer, Satellite> clientSats = new HashMap<>();
+
+	@SideOnly(Side.CLIENT)
+	public static void setClientSats(HashMap<Integer, Satellite> sats) {
+		clientSats = sats;
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static HashMap<Integer, Satellite> getClientSats() {
+		return clientSats;
+	}
+
 }

--- a/src/main/java/com/hbm/saveddata/satellites/Satellite.java
+++ b/src/main/java/com/hbm/saveddata/satellites/Satellite.java
@@ -126,4 +126,6 @@ public abstract class Satellite {
 	 * @param z ditto
 	 */
 	public void onCoordAction(World world, EntityPlayer player, int x, int y, int z) { }
+
+	public abstract float[] getColor();
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteHorizons.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteHorizons.java
@@ -1,6 +1,5 @@
 package com.hbm.saveddata.satellites;
 
-import com.hbm.entity.projectile.EntityTom;
 import com.hbm.main.MainRegistry;
 import com.hbm.saveddata.SatelliteSavedData;
 import com.hbm.saveddata.TomSaveData;
@@ -11,7 +10,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.IChunkProvider;
 
 public class SatelliteHorizons extends Satellite {
 	
@@ -61,4 +59,10 @@ public class SatelliteHorizons extends Satellite {
 			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.RED + "Horizons has been activated."));
 		}
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.0F, 0.0F, 0.0F };
+	}
+
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteLaser.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteLaser.java
@@ -39,4 +39,10 @@ public class SatelliteLaser extends Satellite {
     		world.spawnEntityInWorld(blast);
     	}
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.221F, 0.663F, 1.0F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteMapper.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteMapper.java
@@ -6,4 +6,10 @@ public class SatelliteMapper extends Satellite {
 		this.ifaceAcs.add(InterfaceActions.HAS_MAP);
 		this.satIface = Interfaces.SAT_PANEL;
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.538F, 1.0F, 0.523F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteMiner.java
@@ -45,4 +45,10 @@ public class SatelliteMiner extends Satellite {
 	static {
 		registerCargo(SatelliteMiner.class, ItemPoolsSatellite.POOL_SAT_MINER);
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.0F, 0.0F, 0.0F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteRadar.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteRadar.java
@@ -7,4 +7,10 @@ public class SatelliteRadar extends Satellite {
 		this.ifaceAcs.add(InterfaceActions.HAS_RADAR);
 		this.satIface = Interfaces.SAT_PANEL;
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.134F, 1.0F, 0.134F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteRelay.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteRelay.java
@@ -16,4 +16,10 @@ public class SatelliteRelay extends Satellite {
 		for(Object p : world.playerEntities)
 			((EntityPlayer)p).triggerAchievement(MainRegistry.achFOEQ);
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.0F, 0.0F, 0.0F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteResonator.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteResonator.java
@@ -21,4 +21,10 @@ public class SatelliteResonator extends Satellite {
 		((EntityPlayerMP)player).playerNetServerHandler.setPlayerLocation(x + 0.5D, y, z + 0.5D, player.rotationYaw, player.rotationPitch);
 		world.playSoundEffect(player.posX, player.posY, player.posZ, "mob.endermen.portal", 1.0F, 1.0F);
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 1.0F, 0.646F, 0.181F };
+	}
+	
 }

--- a/src/main/java/com/hbm/saveddata/satellites/SatelliteScanner.java
+++ b/src/main/java/com/hbm/saveddata/satellites/SatelliteScanner.java
@@ -6,4 +6,10 @@ public class SatelliteScanner extends Satellite {
 		this.ifaceAcs.add(InterfaceActions.HAS_ORES);
 		this.satIface = Interfaces.SAT_PANEL;
 	}
+
+	@Override
+	public float[] getColor() {
+		return new float[] { 0.544F, 0.680F, 1.0F };
+	}
+	
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityAtmoExtractor.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityAtmoExtractor.java
@@ -58,8 +58,8 @@ public class TileEntityAtmoExtractor extends TileEntityMachineBase implements IF
 		
 		if(body != null) {
 			CBT_Atmosphere atmosphere = body.getTrait(CBT_Atmosphere.class);
-			if(atmosphere != null) {
-				tanks.setTankType((FluidType) atmosphere.fluids);
+			if(atmosphere != null && atmosphere.fluids.size() > 0) {
+				tanks.setTankType(atmosphere.fluids.get(0).fluid);
 			} else {
 				tanks.setTankType(Fluids.NONE);
 			}

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOven.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterOven.java
@@ -5,8 +5,9 @@ import java.io.IOException;
 import com.google.gson.JsonObject;
 import com.google.gson.stream.JsonWriter;
 import com.hbm.dim.CelestialBody;
-import com.hbm.dim.trait.CelestialBodyTrait.CBT_Breathable;
+import com.hbm.dim.trait.CBT_Atmosphere;
 import com.hbm.inventory.container.ContainerFirebox;
+import com.hbm.inventory.fluid.Fluids;
 import com.hbm.inventory.gui.GUIFirebox;
 import com.hbm.lib.RefStrings;
 import com.hbm.module.ModuleBurnTime;
@@ -56,7 +57,8 @@ public class TileEntityHeaterOven extends TileEntityFireboxBase implements IConf
 	public void updateEntity() {
 		
 		if(!worldObj.isRemote) {
-			if(!CelestialBody.hasTrait(worldObj, CBT_Breathable.class)) {
+			CBT_Atmosphere atmosphere = CelestialBody.getTrait(worldObj, CBT_Atmosphere.class);
+			if(!atmosphere.hasFluid(Fluids.AIR) && !atmosphere.hasFluid(Fluids.OXYGEN)) {
 				return;
 			}
 			this.tryPullHeat();


### PR DESCRIPTION
Atmospheres are now defined solely by partial pressures, which makes terraforming code simpler! For example, pulling all the CO2 from an atmosphere will also reduce the total pressure automatically. This also adds to the difficulty of terraforming Eve, which has 5x the atmospheric pressure on Kerbin.

Also, satellites now show up in the sky around the planets they're launched from!