### PR TITLE
Update build action to use space travel branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "space-travel-twopointfive" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "space-travel-twopointfive" ]
 
 jobs:
   build:


### PR DESCRIPTION
On the hbm repo the build action is set to the master branch, here it should be set to space-travel-twopointfive as that is the main branch here.