### PR TITLE
Reduce calls to System.currentTimeMillis

### DIFF
--- a/src/main/java/com/hbm/render/loader/HbmFace.java
+++ b/src/main/java/com/hbm/render/loader/HbmFace.java
@@ -14,13 +14,13 @@ public class HbmFace {
     public TextureCoordinate[] textureCoordinates;
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(Tessellator tessellator)
+    public void addFaceForRender(float currentTime, Tessellator tessellator)
     {
-        addFaceForRender(tessellator, 0.0005F);
+        addFaceForRender(currentTime, tessellator, 0.0005F);
     }
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(Tessellator tessellator, float textureOffset)
+    public void addFaceForRender(float currentTime, Tessellator tessellator, float textureOffset)
     {
         if (faceNormal == null)
         {
@@ -31,6 +31,7 @@ public class HbmFace {
 
         float averageU = 0F;
         float averageV = 0F;
+	float animOffset = 0F;
 
         if ((textureCoordinates != null) && (textureCoordinates.length > 0))
         {
@@ -42,6 +43,7 @@ public class HbmFace {
 
             averageU = averageU / textureCoordinates.length;
             averageV = averageV / textureCoordinates.length;
+	    animOffset = (float)(((double)currentTime % HmfController.modoloMod) / HmfController.quotientMod);
         }
 
         float offsetU, offsetV;
@@ -63,7 +65,7 @@ public class HbmFace {
                     offsetV = -offsetV;
                 }
 
-                tessellator.addVertexWithUV(vertices[i].x, vertices[i].y, vertices[i].z, textureCoordinates[i].u + offsetU, textureCoordinates[i].v + offsetV + (((double)System.currentTimeMillis() % HmfController.modoloMod) / HmfController.quotientMod));
+                tessellator.addVertexWithUV(vertices[i].x, vertices[i].y, vertices[i].z, textureCoordinates[i].u + offsetU, textureCoordinates[i].v + offsetV + animOffset);
             }
             else
             {

--- a/src/main/java/com/hbm/render/loader/HbmGroupObject.java
+++ b/src/main/java/com/hbm/render/loader/HbmGroupObject.java
@@ -29,25 +29,25 @@ public class HbmGroupObject {
     }
 
     @SideOnly(Side.CLIENT)
-    public void render()
+    public void render(float currentTime)
     {
         if (faces.size() > 0)
         {
             Tessellator tessellator = Tessellator.instance;
             tessellator.startDrawing(glDrawingMode);
-            render(tessellator);
+            render(currentTime, tessellator);
             tessellator.draw();
         }
     }
 
     @SideOnly(Side.CLIENT)
-    public void render(Tessellator tessellator)
+    public void render(float currentTime, Tessellator tessellator)
     {
         if (faces.size() > 0)
         {
             for (HbmFace face : faces)
             {
-                face.addFaceForRender(tessellator);
+                face.addFaceForRender(currentTime, tessellator);
             }
         }
     }

--- a/src/main/java/com/hbm/render/loader/HbmModelObject.java
+++ b/src/main/java/com/hbm/render/loader/HbmModelObject.java
@@ -188,9 +188,10 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAll(Tessellator tessellator)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
-            groupObject.render(tessellator);
+            groupObject.render(currentTime, tessellator);
         }
     }
 
@@ -198,13 +199,14 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderOnly(String... groupNames)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
             {
                 if (groupName.equalsIgnoreCase(groupObject.name))
                 {
-                    groupObject.render();
+                    groupObject.render(currentTime);
                 }
             }
         }
@@ -212,13 +214,14 @@ public class HbmModelObject implements IModelCustom {
 
     @SideOnly(Side.CLIENT)
     public void tessellateOnly(Tessellator tessellator, String... groupNames) {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
             {
                 if (groupName.equalsIgnoreCase(groupObject.name))
                 {
-                    groupObject.render(tessellator);
+                    groupObject.render(currentTime, tessellator);
                 }
             }
         }
@@ -228,22 +231,24 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderPart(String partName)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
             {
-                groupObject.render();
+                groupObject.render(currentTime);
             }
         }
     }
 
     @SideOnly(Side.CLIENT)
     public void tessellatePart(Tessellator tessellator, String partName) {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
             {
-                groupObject.render(tessellator);
+                groupObject.render(currentTime, tessellator);
             }
         }
     }
@@ -252,6 +257,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void renderAllExcept(String... excludedGroupNames)
     {
+	float currentTime = System.currentTimeMillis();
         for (HbmGroupObject groupObject : groupObjects)
         {
             boolean skipPart=false;
@@ -264,7 +270,7 @@ public class HbmModelObject implements IModelCustom {
             }
             if(!skipPart)
             {
-                groupObject.render();
+                groupObject.render(currentTime);
             }
         }
     }
@@ -272,6 +278,7 @@ public class HbmModelObject implements IModelCustom {
     @SideOnly(Side.CLIENT)
     public void tessellateAllExcept(Tessellator tessellator, String... excludedGroupNames)
     {
+	float currentTime = System.currentTimeMillis();
         boolean exclude;
         for (HbmGroupObject groupObject : groupObjects)
         {
@@ -285,7 +292,7 @@ public class HbmModelObject implements IModelCustom {
             }
             if(!exclude)
             {
-                groupObject.render(tessellator);
+                groupObject.render(currentTime, tessellator);
             }
         }
     }


### PR DESCRIPTION
This improves rendering performance in a laggy scene on my machine (Linux 6.12.16), from around 20 fps originally to around 50 fps with the patch.

Previously the code was getting the system time once for every vertex in an animated face, now it should only need to be called once per model.

Getting the system time can actually be quite an expensive operation, depending on what timer your computer is using, and I believe is also a system call, which will also make it expensive as the processor has to switch to executing kernel code (and seems to cause spark to miss just how great the performance impact is).