### PR TITLE
Minor improvement to recipes

### DIFF
--- a/src/main/java/com/hbm/inventory/recipes/AssemblyMachineRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblyMachineRecipes.java
@@ -135,7 +135,7 @@ public class AssemblyMachineRecipes extends GenericRecipes<GenericRecipe> {
 				.inputItems(new OreDictStack(DURA.plateCast(), 1), new OreDictStack(TI.plate(), 8)));
 		this.register(new GenericRecipe("ass.entanglementkit").setup(200, 100).outputItems(new ItemStack(ModItems.entanglement_kit, 1))
 				.inputItems(new OreDictStack(DURA.plateCast(), 4), new OreDictStack(CU.plate(), 24), new OreDictStack(GOLD.wireDense(), 16))
-				.inputFluids(new FluidStack(Fluids.XENON, 8_000)));
+				.inputFluids(new FluidStack(Fluids.KRYPTON, 8_000)));
 		this.register(new GenericRecipe("ass.protoreactor").setup(200, 100).outputItems(new ItemStack(ModItems.dysfunctional_reactor, 1))
 				.inputItems(new OreDictStack(STEEL.shell(), 4), new OreDictStack(PB.plateCast(), 4), new ComparableStack(ModItems.rod_quad_empty, 10), new OreDictStack(KEY_BROWN, 3)));
 

--- a/src/main/java/com/hbm/inventory/recipes/AssemblyMachineRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblyMachineRecipes.java
@@ -1206,14 +1206,14 @@ public class AssemblyMachineRecipes extends GenericRecipes<GenericRecipe> {
 						new OreDictStack(ANY_RUBBER.ingot(), 4),
 						new ComparableStack(ModItems.thruster_small, 1),
 						new ComparableStack(ModItems.circuit, 1, EnumCircuitType.AVIONICS)));
-		this.register(new GenericRecipe("ass.stardar").setup(400, 100).outputItems(new ItemStack(ModBlocks.machine_stardar, 1))
+		this.register(new GenericRecipe("ass.stardar").setup(400, 100).outputItems(new ItemStack(ModBlocks.machine_stardar, 1)).setPools(GenericRecipes.POOL_PREFIX_DISCOVER + "stardar")
 				.inputItems(
 						new ComparableStack(ModItems.motor, 4),
 						new ComparableStack(ModItems.sat_head_radar),
 						new OreDictStack(ANY_CONCRETE.any(), 16),
 						new ComparableStack(ModBlocks.steel_scaffold, 8),
 						new ComparableStack(ModItems.circuit, 4, EnumCircuitType.BASIC)));
-		this.register(new GenericRecipe("ass.driveprocessor").setup(400, 100).outputItems(new ItemStack(ModBlocks.machine_drive_processor, 1))
+		this.register(new GenericRecipe("ass.driveprocessor").setup(400, 100).outputItems(new ItemStack(ModBlocks.machine_drive_processor, 1)).setPools(GenericRecipes.POOL_PREFIX_DISCOVER + "stardar")
 				.inputItems(
 						new OreDictStack(ANY_RUBBER.ingot(), 2),
 						new OreDictStack(CU.wireFine(), 4),

--- a/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
@@ -372,7 +372,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.HYDROGEN, 4_000))
 				.outputFluids(new FluidStack(Fluids.THORIUM_BROMIDE, 4_000)));
 
-		this.register(new GenericRecipe("chem.hydrazine").setup(250, 1_000)
+		this.register(new GenericRecipe("chem.hydrazine").setup(250, 1_000).setIcon(ModItems.gas_full, Fluids.HYDRAZINE.getID())
 				.inputFluids(new FluidStack(Fluids.NITRIC_ACID, 2_000), new FluidStack(Fluids.AMMONIA, 1_000))
 				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)));
 
@@ -380,7 +380,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.NITROGEN, 600), new FluidStack(Fluids.WATER, 1_000))
 				.outputFluids(new FluidStack(Fluids.AMMONIA, 800)));
 
-		this.register(new GenericRecipe("chem.bloodfuel").setup(250, 1_000)
+		this.register(new GenericRecipe("chem.bloodfuel").setup(250, 1_000).setIcon(ModItems.gas_full, Fluids.BLOODGAS.getID())
 				.inputFluids(new FluidStack(Fluids.AMMONIA, 350), new FluidStack(Fluids.BLOOD, 800))
 				.outputFluids(new FluidStack(Fluids.BLOODGAS, 1000)));
 
@@ -452,15 +452,15 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.GAS, 750), new FluidStack(Fluids.CHLORINE, 250))
 				.outputFluids(new FluidStack(Fluids.CHLOROMETHANE, 1000)));
 
-		this.register(new GenericRecipe("chem.nitricacidalt").setup(50, 1_000)
+		this.register(new GenericRecipe("chem.nitricacidalt")..setupNamed(50, 1_000)
 				.inputFluids(new FluidStack(Fluids.WATER, 500), new FluidStack(Fluids.AMMONIA, 1000))
 				.outputFluids(new FluidStack(Fluids.NITRIC_ACID, 1_000)));
 
 		// WARNING: NILERED CHEMISTRY ZONE //
-		this.register(new GenericRecipe("chem.hydrapiss").setup(250, 1_000)
+		this.register(new GenericRecipe("chem.hydrapiss")..setupNamed(250, 1_000).setIcon(ModItems.gas_full, Fluids.HYDRAZINE.getID())
 				.inputFluids(new FluidStack(Fluids.NITRIC_ACID, 2000))
 				.inputItems(new ComparableStack(ModItems.rag_piss)) // urea...
-				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)));
+				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)).setPools(GenericRecipes.POOL_PREFIX_ALT + ".hydrapiss"));
 
 		this.register(new GenericRecipe("chem.synleather").setup(200, 500)
 				.inputFluids(new FluidStack(Fluids.PEROXIDE, 250))

--- a/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
@@ -452,12 +452,12 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.GAS, 750), new FluidStack(Fluids.CHLORINE, 250))
 				.outputFluids(new FluidStack(Fluids.CHLOROMETHANE, 1000)));
 
-		this.register(new GenericRecipe("chem.nitricacidalt")..setupNamed(50, 1_000)
+		this.register(new GenericRecipe("chem.nitricacidalt").setupNamed(50, 1_000)
 				.inputFluids(new FluidStack(Fluids.WATER, 500), new FluidStack(Fluids.AMMONIA, 1000))
 				.outputFluids(new FluidStack(Fluids.NITRIC_ACID, 1_000)));
 
 		// WARNING: NILERED CHEMISTRY ZONE //
-		this.register(new GenericRecipe("chem.hydrapiss")..setupNamed(250, 1_000).setIcon(ModItems.canister_full, Fluids.HYDRAZINE.getID())
+		this.register(new GenericRecipe("chem.hydrapiss").setupNamed(250, 1_000).setIcon(ModItems.canister_full, Fluids.HYDRAZINE.getID())
 				.inputFluids(new FluidStack(Fluids.NITRIC_ACID, 2000))
 				.inputItems(new ComparableStack(ModItems.rag_piss)) // urea...
 				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)).setPools(GenericRecipes.POOL_PREFIX_ALT + ".hydrapiss"));

--- a/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/ChemicalPlantRecipes.java
@@ -372,7 +372,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.HYDROGEN, 4_000))
 				.outputFluids(new FluidStack(Fluids.THORIUM_BROMIDE, 4_000)));
 
-		this.register(new GenericRecipe("chem.hydrazine").setup(250, 1_000).setIcon(ModItems.gas_full, Fluids.HYDRAZINE.getID())
+		this.register(new GenericRecipe("chem.hydrazine").setup(250, 1_000).setIcon(ModItems.canister_full, Fluids.HYDRAZINE.getID())
 				.inputFluids(new FluidStack(Fluids.NITRIC_ACID, 2_000), new FluidStack(Fluids.AMMONIA, 1_000))
 				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)));
 
@@ -380,7 +380,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.inputFluids(new FluidStack(Fluids.NITROGEN, 600), new FluidStack(Fluids.WATER, 1_000))
 				.outputFluids(new FluidStack(Fluids.AMMONIA, 800)));
 
-		this.register(new GenericRecipe("chem.bloodfuel").setup(250, 1_000).setIcon(ModItems.gas_full, Fluids.BLOODGAS.getID())
+		this.register(new GenericRecipe("chem.bloodfuel").setup(250, 1_000).setIcon(ModItems.canister_full, Fluids.BLOODGAS.getID())
 				.inputFluids(new FluidStack(Fluids.AMMONIA, 350), new FluidStack(Fluids.BLOOD, 800))
 				.outputFluids(new FluidStack(Fluids.BLOODGAS, 1000)));
 
@@ -457,7 +457,7 @@ public class ChemicalPlantRecipes extends GenericRecipes<GenericRecipe> {
 				.outputFluids(new FluidStack(Fluids.NITRIC_ACID, 1_000)));
 
 		// WARNING: NILERED CHEMISTRY ZONE //
-		this.register(new GenericRecipe("chem.hydrapiss")..setupNamed(250, 1_000).setIcon(ModItems.gas_full, Fluids.HYDRAZINE.getID())
+		this.register(new GenericRecipe("chem.hydrapiss")..setupNamed(250, 1_000).setIcon(ModItems.canister_full, Fluids.HYDRAZINE.getID())
 				.inputFluids(new FluidStack(Fluids.NITRIC_ACID, 2000))
 				.inputItems(new ComparableStack(ModItems.rag_piss)) // urea...
 				.outputFluids(new FluidStack(Fluids.HYDRAZINE, 800)).setPools(GenericRecipes.POOL_PREFIX_ALT + ".hydrapiss"));

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -625,6 +625,9 @@ chem.heavylube=Lubricant from Heavy Oil
 chem.oilelectrodes=Instant Electrodes (Heating Oil)
 chem.lubeelectrodes=Instant Electrodes (Lubricant)
 
+chem.nitricacidalt=Nitric Acid from Ammonia
+chem.hydrapiss=Hydrazine via Urea
+
 chem.ARSENIC=Arsenic Extraction
 chem.ASPHALT=Asphalt Production
 chem.AMONGUS=Ammonia Production


### PR DESCRIPTION
I think these changes useful and more balanced.

* The Hydrazine and Blood Fuel recipes now have a canister icon!
  * As in original.
* Now in Entanglement Kit recipe, Krypton is used instead of Xenon.
* To craft StarDar and Drive Processor, a blueprint is required.
  * The same applies to alt recipe Hydrazine