### PR TITLE
Small Ru Fix Entity Name

### DIFF
--- a/src/main/resources/assets/hbm/lang/ru_RU.lang
+++ b/src/main/resources/assets/hbm/lang/ru_RU.lang
@@ -7348,19 +7348,17 @@ container.hydrobay=Теплица
 container.machine_discharger=Устройство разрядки материи
 
 // Entities //
-entity.entity_depthsquid.name=Глубинный кальмар
-entity.entity_mob_flesh_creeper.name=Мясной крипер
-entity.entity_moon_cow.name=Лунная корова
-entity.entity_rideable_rocket.name=Ракета
-entity.entity_rideable_rocket_dummy.name=Ракета
-entity.entity_scrapfish.name=Металлоломорыба
-entity.entity_scutterfish.name=Скаттер
-entity.entity_scuttlecrab.name=Краб-бегун
-entity.entity_siftereel.name=Угорь-просейщик
-entity.entity_tankbot.name=Танкбот
-// Vitya note: Может быть лучше перевести как "Машина войны?".
-// Колосс звучит слишком литературно. В простонародье редко используется.
-entity.entity_war_behemoth.name=Колосс войны
+entity.hbm.entity_depthsquid.name=Глубинный кальмар
+entity.hbm.entity_mob_flesh_creeper.name=Мясной крипер
+entity.hbm.entity_moon_cow.name=Лунная корова
+entity.hbm.entity_rideable_rocket.name=Ракета
+entity.hbm.entity_rideable_rocket_dummy.name=Ракета
+entity.hbm.entity_scrapfish.name=Металлоломорыба
+entity.hbm.entity_scutterfish.name=Скаттер
+entity.hbm.entity_scuttlecrab.name=Краб-бегун
+entity.hbm.entity_siftereel.name=Угорь-просейщик
+entity.hbm.entity_tankbot.name=Танкбот
+entity.hbm.entity_war_behemoth.name=Колосс войны
 
 // Templates (Old) //
 chem.ANIMAN=Синтез литературного ужаса
@@ -7478,4 +7476,4 @@ desc.util.warhead=Боеголовка
 desc.util.chip_inaccuracy=Неточность чипа
 desc.util.fin_inaccuracy=Неточность стабилизатора
 
-// last updated november 25th, 2025 by KimiKimi //
+// last updated november 29th, 2025 by KimiKimi //


### PR DESCRIPTION
Initially, I created a translation pr just to fix entitys translations.
After one update, they stopped working due to the missing ".hbm" prefix.