### PR TITLE
Fix incorrect OreDictionary key for NaquadahEnriched

### DIFF
--- a/src/main/java/com/hbm/crafting/RodRecipes.java
+++ b/src/main/java/com/hbm/crafting/RodRecipes.java
@@ -172,7 +172,7 @@ public class RodRecipes {
 	
 	public static void registerInit() {
 		/* GT6 */
-		if(OreDictionary.doesOreNameExist("ingotNaquadah-Enriched"))	addPellet(new DictFrame("Naquadah-Enriched"),	EnumWatzType.NQD);
+		if(OreDictionary.doesOreNameExist("ingotNaquadahEnriched"))	addPellet(new DictFrame("NaquadahEnriched"),	EnumWatzType.NQD);
 		if(OreDictionary.doesOreNameExist("ingotNaquadria"))			addPellet(new DictFrame("Naquadria"),			EnumWatzType.NQR);
 		CraftingManager.addShapelessAuto(new ItemStack(ModItems.rbmk_fuel_drx, 1), new Object[] { ModItems.rbmk_fuel_balefire, ModItems.particle_digamma });
 


### PR DESCRIPTION
Fixes incorrect OreDictionary key "ingotNaquadah-Enriched".
The correct key should be "ingotNaquadahEnriched".
