### PR TITLE
Fix rocket zoom mod incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,9 +93,9 @@ repositories {
 		url = "https://cursemaven.com"
 	}
 	maven {
-        name = "OpenComputers"
-        url = "https://maven.cil.li/"
-    }
+		name = "OpenComputers"
+		url = "https://maven.cil.li/"
+	}
 }
 
 dependencies {

--- a/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerRenderer.java
@@ -67,6 +67,9 @@ import org.lwjgl.opengl.GLContext;
 
 public class ModEventHandlerRenderer {
 
+	private float previousZoom = 4.0F;
+	private boolean previousZoomActive = false;
+
 	private static ModelMan manlyModel;
 	private static boolean[] partsHidden = new boolean[7];
 
@@ -78,9 +81,16 @@ public class ModEventHandlerRenderer {
 		if(event.phase == Phase.START) {
 			// Zoom out third person view when inside a rocket
 			if(player != null && player.ridingEntity != null && player.ridingEntity instanceof EntityRideableRocket) {
+				if(previousZoomActive == false) {
+					previousZoom = mc.entityRenderer.thirdPersonDistance;
+					previousZoomActive = true;
+				}
 				mc.entityRenderer.thirdPersonDistance = 12.0F;
 			} else {
-				mc.entityRenderer.thirdPersonDistance = 4.0F;
+				if(previousZoomActive == true) {
+					previousZoomActive = false;
+					mc.entityRenderer.thirdPersonDistance = previousZoom;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
changes in the airport:
- rocket camera zoom saves current zoom before overriding it, and then restores the previous zoom when the player is no longer inside the rocket
- changed some spaces to tabs in ``build.gradle``. unnecessary i know but i was trying to figure out why gradle couldn't get opencomputers' metadata